### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "Flask",
     "pulp",
     "transformers",
-    "pyautogen",
+    "ag2",
     "scikit-learn",
     "numpy",
     "lxml",

--- a/uv.lock
+++ b/uv.lock
@@ -9,11 +9,11 @@ anyio==4.9.0
     #   asyncer
     #   httpx
     #   openai
-    #   pyautogen
+    #   ag2
 asttokens==3.0.0
     # via stack-data
 asyncer==0.0.8
-    # via pyautogen
+    # via ag2
 attrs==25.3.0
     # via
     #   jsonschema
@@ -49,11 +49,11 @@ comm==0.2.2
 decorator==5.2.1
     # via ipython
 diskcache==5.6.3
-    # via pyautogen
+    # via ag2
 distro==1.9.0
     # via openai
 docker==7.1.0
-    # via pyautogen
+    # via ag2
 executing==2.2.0
     # via stack-data
 filelock==3.18.0
@@ -78,7 +78,7 @@ httpx==0.28.1
     # via
     #   langsmith
     #   openai
-    #   pyautogen
+    #   ag2
 huggingface-hub==0.33.4
     # via
     #   tokenizers
@@ -159,7 +159,7 @@ packaging==24.2
     #   huggingface-hub
     #   langchain-core
     #   langsmith
-    #   pyautogen
+    #   ag2
     #   streamlit
     #   transformers
 pandas==2.3.1
@@ -180,7 +180,7 @@ pure-eval==0.2.3
     # via stack-data
 pyarrow==20.0.0
     # via streamlit
-pyautogen==0.9
+ag2==0.9
     # via nf-llm (pyproject.toml)
 pydantic==2.11.7
     # via
@@ -188,7 +188,7 @@ pydantic==2.11.7
     #   langchain-core
     #   langsmith
     #   openai
-    #   pyautogen
+    #   ag2
 pydantic-core==2.33.2
     # via pydantic
 pydeck==0.9.1
@@ -200,7 +200,7 @@ pygments==2.19.2
 python-dateutil==2.9.0.post0
     # via pandas
 python-dotenv==1.1.1
-    # via pyautogen
+    # via ag2
 pytz==2025.2
     # via pandas
 pywin32==310
@@ -263,11 +263,11 @@ tenacity==9.1.2
     #   langchain-core
     #   streamlit
 termcolor==3.1.0
-    # via pyautogen
+    # via ag2
 threadpoolctl==3.6.0
     # via scikit-learn
 tiktoken==0.9.0
-    # via pyautogen
+    # via ag2
 tokenizers==0.21.2
     # via transformers
 toml==0.10.2


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using AG2! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
