### PR TITLE
Add README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# NF LLM
+
+This project contains utilities for collecting fantasy football data and generating optimized lineups using large language models.
+
+## Quick start
+
+1. **Install dependencies**
+   ```bash
+   make install
+   ```
+   This uses [`uv`](https://github.com/astral-sh/uv) to create a local virtual environment and install the packages defined in `pyproject.toml`.
+
+2. **Run tests**
+   ```bash
+   pytest
+   ```
+
+3. **Initialize the database**
+   ```bash
+   nf-llm db init
+   ```
+
+4. **Collect data**
+   ```bash
+   python -m nf_llm.collect --dk_contest_type Main
+   ```
+
+5. **Run the lineup optimizer**
+   ```bash
+   python -m nf_llm.app
+   ```
+   The optimizer expects an environment variable `OPENAI_API_KEY` for LLM access.
+
+For more detailed usage, inspect the source files under `src/nf_llm`.


### PR DESCRIPTION
## Summary
- add project README with quick start instructions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'duckdb')*
- `PYTHONPATH=src pytest -q` *(fails: ModuleNotFoundError: No module named 'duckdb')*

------
https://chatgpt.com/codex/tasks/task_e_68830eb89d888322931d7023b6874466