### PR TITLE
Add ESPN weekly script and improve team detection

### DIFF
--- a/src/nf_llm/espn_weekly.py
+++ b/src/nf_llm/espn_weekly.py
@@ -1,0 +1,66 @@
+"""Command line utility for weekly ESPN fantasy football insights."""
+from __future__ import annotations
+
+import os
+
+try:  # pragma: no cover - optional dependency
+    from espn_api.football import League  # type: ignore
+except Exception:  # pragma: no cover - handled at runtime
+    League = None  # type: ignore
+
+from .fantasy_football.espn import (
+    _find_user_team,
+    get_matchup,
+    recommend_lineup,
+    suggest_free_agents,
+)
+
+
+def _env(name: str, default: str | None = None) -> str:
+    value = os.getenv(name, default)
+    if value is None:
+        raise RuntimeError(f"Environment variable {name} is required")
+    return value
+
+
+def main() -> None:
+    if League is None:  # pragma: no cover - dependency not installed
+        raise ImportError("espn-api package is required to fetch ESPN data")
+
+    league_id = int(_env("LEAGUE_ID"))
+    year = int(_env("LEAGUE_YEAR"))
+    swid = _env("SWID")
+    espn_s2 = _env("ESPN_S2")
+
+    league = League(league_id=league_id, year=year, swid=swid, espn_s2=espn_s2)
+    team = _find_user_team(league, swid)
+    if team is None:
+        raise RuntimeError("Could not locate team for provided credentials")
+
+    print("== Roster ==")
+    for player in getattr(team, "roster", []):
+        name = getattr(player, "name", "")
+        pos = getattr(player, "position", "")
+        proj = getattr(player, "projected_points", 0)
+        print(f"{pos:>3}  {name:<25} {proj:5.1f}")
+
+    print("\n== Suggested Lineup ==")
+    lineup = recommend_lineup(team)
+    for slot, players in lineup.items():
+        for p in players:
+            print(f"{slot:>5}: {p['name']} ({p['position']}) {p['projected_points']:.1f}")
+
+    opp = get_matchup(league, getattr(team, "team_id", 0))
+    if opp is not None:
+        print("\n== Matchup ==")
+        print(f"Vs. {getattr(opp, 'team_name', 'Unknown')}")
+
+    print("\n== Free Agent Suggestions ==")
+    for fa in suggest_free_agents(league, team):
+        print(
+            f"{fa['position']:>3}  {fa['name']:<25} {fa['projected_points']:.1f}"
+        )
+
+
+if __name__ == "__main__":  # pragma: no cover - script entry point
+    main()

--- a/src/nf_llm/fantasy_football/espn.py
+++ b/src/nf_llm/fantasy_football/espn.py
@@ -1,7 +1,7 @@
 """Utilities for retrieving ESPN fantasy football data."""
 from __future__ import annotations
 
-from typing import Any, List, Dict
+from typing import Any, Dict, List
 
 try:  # pragma: no cover - import guard for optional dependency
     from espn_api.football import League  # type: ignore
@@ -9,36 +9,56 @@ except Exception:  # pragma: no cover - handled at runtime
     League = None  # type: ignore
 
 
+def _normalise_id(identifier: str) -> str:
+    """Return an ESPN identifier in normalised form.
+
+    IDs returned by the API may include surrounding braces or differ in case.  By
+    stripping the braces and lowering the case we can compare identifiers
+    reliably.
+    """
+
+    return identifier.strip("{}").lower()
+
+
+def _find_user_team(league: Any, swid: str) -> Any:
+    """Locate the team object belonging to the user identified by ``swid``.
+
+    The espn-api library sets ``league.team_id`` only for primary managers.  When
+    the user is a co-manager the library falls back to the first team in the
+    league.  To ensure the correct team is returned we scan each team's owners
+    for the provided ``swid``.
+    """
+
+    normalised = _normalise_id(swid)
+    for team in getattr(league, "teams", []):
+        owners = [
+            _normalise_id(o) for o in getattr(team, "owners", []) or []
+        ]
+        if normalised in owners:
+            return team
+
+    # Fallback to the team detected by the library if no owner match is found.
+    team_id = getattr(league, "team_id", None)
+    return next(
+        (t for t in getattr(league, "teams", []) if getattr(t, "team_id", None) == team_id),
+        None,
+    )
+
+
 def get_user_team(league_id: int, year: int, swid: str, espn_s2: str) -> List[Dict[str, Any]]:
     """Return the roster for the team associated with the provided credentials.
 
-    Parameters
-    ----------
-    league_id: int
-        ESPN league identifier.
-    year: int
-        Season year of the league.
-    swid: str
-        SWID token from the user's ESPN cookies.
-    espn_s2: str
-        ESPN_S2 token from the user's ESPN cookies.
-
-    Returns
-    -------
-    list of dict
-        Each dict contains player information such as ``name`` and ``position``.
+    The function now supports both primary managers and co-managers by searching
+    the league's teams for one that lists the provided ``swid`` as an owner.
     """
+
     if League is None:  # pragma: no cover - dependency not installed
         raise ImportError("espn-api package is required to fetch ESPN data")
 
     league = League(league_id=league_id, year=year, swid=swid, espn_s2=espn_s2)
-    team_id = getattr(league, "team_id", None)
-    if team_id is None:
-        raise ValueError("Could not determine team for provided credentials")
-
-    team = next((t for t in league.teams if getattr(t, "team_id", None) == team_id), None)
+    team = _find_user_team(league, swid)
     if team is None:
-        raise ValueError(f"Team {team_id} not found in league {league_id}")
+        raise ValueError("Could not determine team for provided credentials")
 
     roster: List[Dict[str, Any]] = []
     for player in getattr(team, "roster", []):
@@ -50,3 +70,108 @@ def get_user_team(league_id: int, year: int, swid: str, espn_s2: str) -> List[Di
             }
         )
     return roster
+
+
+def recommend_lineup(team: Any) -> Dict[str, List[Dict[str, Any]]]:
+    """Suggest a starting lineup based on projected points.
+
+    Parameters
+    ----------
+    team: Any
+        Team object returned by ``espn-api``.
+
+    Returns
+    -------
+    dict
+        Mapping of lineup slot to selected player dictionaries.  Only a simple
+        heuristic is used: the highest ``projected_points`` players are chosen
+        for each position with a single FLEX spot (RB/WR/TE).
+    """
+
+    slots = {"QB": 1, "RB": 2, "WR": 3, "TE": 1, "DST": 1, "FLEX": 1}
+    flex_positions = {"RB", "WR", "TE"}
+    lineup: Dict[str, List[Dict[str, Any]]] = {slot: [] for slot in slots}
+
+    players = sorted(
+        getattr(team, "roster", []),
+        key=lambda p: getattr(p, "projected_points", 0),
+        reverse=True,
+    )
+
+    for player in players:
+        pos = getattr(player, "position", "")
+        if pos in slots and len(lineup[pos]) < slots[pos]:
+            lineup[pos].append(
+                {
+                    "name": getattr(player, "name", ""),
+                    "position": pos,
+                    "projected_points": getattr(player, "projected_points", 0),
+                }
+            )
+        elif pos in flex_positions and len(lineup["FLEX"]) < slots["FLEX"]:
+            lineup["FLEX"].append(
+                {
+                    "name": getattr(player, "name", ""),
+                    "position": pos,
+                    "projected_points": getattr(player, "projected_points", 0),
+                }
+            )
+
+    return lineup
+
+
+def get_matchup(league: Any, team_id: int, week: int | None = None) -> Any:
+    """Return the opponent for ``team_id`` in the given ``week``.
+
+    Parameters
+    ----------
+    league: Any
+        ``League`` object from ``espn-api``.
+    team_id: int
+        Identifier of the user's team.
+    week: int, optional
+        Week to fetch matchup information for.  Defaults to the current week as
+        determined by ``espn-api``.
+    """
+
+    for box in getattr(league, "box_scores", lambda w: [])(week):
+        if getattr(getattr(box, "home_team", None), "team_id", None) == team_id:
+            return getattr(box, "away_team", None)
+        if getattr(getattr(box, "away_team", None), "team_id", None) == team_id:
+            return getattr(box, "home_team", None)
+    return None
+
+
+def suggest_free_agents(
+    league: Any, team: Any, week: int | None = None, limit: int = 5
+) -> List[Dict[str, Any]]:
+    """Return free agents projected to outperform current rostered players.
+
+    A simple comparison is performed: if a free agent's ``projected_points``
+    exceeds the lowest projected player on the roster at the same position the
+    free agent is recommended.
+    """
+
+    roster_by_pos: Dict[str, List[float]] = {}
+    for player in getattr(team, "roster", []):
+        pos = getattr(player, "position", "")
+        roster_by_pos.setdefault(pos, []).append(
+            float(getattr(player, "projected_points", 0))
+        )
+
+    suggestions: List[Dict[str, Any]] = []
+    for fa in getattr(league, "free_agents", lambda **_: [])(week=week):
+        pos = getattr(fa, "position", "")
+        proj = float(getattr(fa, "projected_points", 0))
+        worst = min(roster_by_pos.get(pos, [float("inf")]))
+        if proj > worst:
+            suggestions.append(
+                {
+                    "name": getattr(fa, "name", ""),
+                    "position": pos,
+                    "projected_points": proj,
+                }
+            )
+
+    suggestions.sort(key=lambda p: p["projected_points"], reverse=True)
+    return suggestions[:limit]

--- a/tests/test_espn.py
+++ b/tests/test_espn.py
@@ -5,7 +5,12 @@ from unittest.mock import Mock, patch
 # Ensure src directory is on path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
-from nf_llm.fantasy_football.espn import get_user_team
+from nf_llm.fantasy_football.espn import (
+    get_user_team,
+    get_matchup,
+    recommend_lineup,
+    suggest_free_agents,
+)
 
 
 def test_get_user_team_returns_roster():
@@ -32,4 +37,97 @@ def test_get_user_team_returns_roster():
     )
     assert roster == [
         {"name": "Tom Brady", "position": "QB", "proTeam": "NE"}
+    ]
+
+
+def test_get_user_team_handles_comanager():
+    swid = "{USER}"  # swid with braces to test normalisation
+
+    player = Mock()
+    player.name = "Co QB"
+    player.position = "QB"
+    player.proTeam = "TB"
+
+    team1 = Mock()
+    team1.team_id = 1
+    team1.owners = ["{OTHER}"]
+    team1.roster = []
+
+    team2 = Mock()
+    team2.team_id = 2
+    team2.owners = [swid, "{OTHER2}"]
+    team2.roster = [player]
+
+    league = Mock()
+    league.team_id = 1  # library would incorrectly point to team1
+    league.teams = [team1, team2]
+
+    with patch("nf_llm.fantasy_football.espn.League", return_value=league):
+        roster = get_user_team(1, 2024, swid, "token")
+
+    assert roster == [{"name": "Co QB", "position": "QB", "proTeam": "TB"}]
+
+
+def test_recommend_lineup_selects_best_players():
+    qb1 = Mock(); qb1.position = "QB"; qb1.name = "QB1"; qb1.projected_points = 15
+    qb2 = Mock(); qb2.position = "QB"; qb2.name = "QB2"; qb2.projected_points = 10
+    rb1 = Mock(); rb1.position = "RB"; rb1.name = "RB1"; rb1.projected_points = 12
+    rb2 = Mock(); rb2.position = "RB"; rb2.name = "RB2"; rb2.projected_points = 8
+    wr1 = Mock(); wr1.position = "WR"; wr1.name = "WR1"; wr1.projected_points = 9
+    wr2 = Mock(); wr2.position = "WR"; wr2.name = "WR2"; wr2.projected_points = 7
+    wr3 = Mock(); wr3.position = "WR"; wr3.name = "WR3"; wr3.projected_points = 6
+    te1 = Mock(); te1.position = "TE"; te1.name = "TE1"; te1.projected_points = 5
+    dst = Mock(); dst.position = "DST"; dst.name = "DST"; dst.projected_points = 4
+
+    team = Mock()
+    team.roster = [qb1, qb2, rb1, rb2, wr1, wr2, wr3, te1, dst]
+
+    lineup = recommend_lineup(team)
+    assert lineup["QB"][0]["name"] == "QB1"
+    assert len(lineup["RB"]) == 2
+    assert len(lineup["WR"]) == 3
+    assert lineup["TE"][0]["name"] == "TE1"
+    assert lineup["DST"][0]["name"] == "DST"
+
+
+def test_get_matchup_returns_opponent():
+    team_id = 2
+    opponent = Mock()
+    opponent.team_id = 3
+
+    box = Mock()
+    box.home_team = Mock(team_id=team_id)
+    box.away_team = opponent
+
+    league = Mock()
+    league.box_scores.return_value = [box]
+
+    result = get_matchup(league, team_id, week=1)
+    assert result is opponent
+
+
+def test_suggest_free_agents_identifies_better_players():
+    roster_player = Mock()
+    roster_player.position = "RB"
+    roster_player.projected_points = 5
+
+    team = Mock()
+    team.roster = [roster_player]
+
+    fa_better = Mock()
+    fa_better.name = "Better"
+    fa_better.position = "RB"
+    fa_better.projected_points = 10
+
+    fa_worse = Mock()
+    fa_worse.name = "Worse"
+    fa_worse.position = "RB"
+    fa_worse.projected_points = 3
+
+    league = Mock()
+    league.free_agents.return_value = [fa_better, fa_worse]
+
+    suggestions = suggest_free_agents(league, team, week=1, limit=5)
+    assert suggestions == [
+        {"name": "Better", "position": "RB", "projected_points": 10.0}
     ]


### PR DESCRIPTION
## Summary
- handle co-manager credentials when retrieving ESPN roster
- provide lineup suggestions, matchup lookup and free agent recommendations
- add command line `espn_weekly` script for weekly insights

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68b493d00db08322aaed74a1be4fc46e