### PR TITLE
Add ESPN lineup optimizer with pickup suggestions

### DIFF
--- a/src/nf_llm/app.py
+++ b/src/nf_llm/app.py
@@ -383,11 +383,8 @@ def create_espn_team_ui():
         try:
             import datetime
             from espn_api.football import League
-            from nf_llm.fantasy_football.espn import (
-                _find_user_team,
-                recommend_lineup,
-                suggest_free_agents,
-            )
+            from nf_llm.fantasy_football.espn import _find_user_team
+            from nf_llm.fantasy_football.espn_optimizer import build_optimal_lineup
 
             current_year = datetime.datetime.now().year
             league = League(
@@ -416,13 +413,15 @@ def create_espn_team_ui():
             else:
                 st.info("No players found for this team.")
 
-            lineup = recommend_lineup(team, league)
-            st.subheader("Suggested Lineup")
-            st.json(lineup)
+            result = build_optimal_lineup(team, league)
+            st.subheader("Optimal Lineup")
+            st.json(result["lineup"])
 
-            suggestions = suggest_free_agents(league, team)
-            st.subheader("Free Agent Suggestions")
-            st.json(suggestions)
+            st.subheader("Suggested Pickups")
+            if result["pickups"]:
+                st.json(result["pickups"])
+            else:
+                st.info("No significant pickups found.")
         except Exception as e:  # pragma: no cover - UI feedback only
             st.error(f"Failed to load team: {e}")
 

--- a/src/nf_llm/espn_weekly.py
+++ b/src/nf_llm/espn_weekly.py
@@ -9,12 +9,8 @@ try:  # pragma: no cover - optional dependency
 except Exception:  # pragma: no cover - handled at runtime
     League = None  # type: ignore
 
-from .fantasy_football.espn import (
-    _find_user_team,
-    get_matchup,
-    recommend_lineup,
-    suggest_free_agents,
-)
+from .fantasy_football.espn import _find_user_team, get_matchup
+from .fantasy_football.espn_optimizer import build_optimal_lineup
 
 
 def _env(name: str, default: str | None = None) -> str:
@@ -46,8 +42,8 @@ def main() -> None:
         print(f"{pos:>3}  {name:<25} {proj:5.1f}")
 
     print("\n== Suggested Lineup ==")
-    lineup = recommend_lineup(team, league)
-    for slot, players in lineup.items():
+    result = build_optimal_lineup(team, league)
+    for slot, players in result["lineup"].items():
         for p in players:
             print(f"{slot:>5}: {p['name']} ({p['position']}) {p['projected_points']:.1f}")
 
@@ -57,10 +53,12 @@ def main() -> None:
         print(f"Vs. {getattr(opp, 'team_name', 'Unknown')}")
 
     print("\n== Free Agent Suggestions ==")
-    for fa in suggest_free_agents(league, team):
-        print(
-            f"{fa['position']:>3}  {fa['name']:<25} {fa['projected_points']:.1f}"
-        )
+    for pickup in result["pickups"]:
+        name = pickup["add"]
+        pos = pickup["position"]
+        gain = pickup["projected_points_gain"]
+        drop = pickup["drop"] or "FA"
+        print(f"{pos:>3}  {name:<25} +{gain:.1f} over {drop}")
 
 
 if __name__ == "__main__":  # pragma: no cover - script entry point

--- a/src/nf_llm/fantasy_football/espn.py
+++ b/src/nf_llm/fantasy_football/espn.py
@@ -146,6 +146,17 @@ def _lineup_slots(league: Any | None) -> Tuple[Dict[str, int], Dict[str, Set[str
     return slots, flex
 
 
+def lineup_slots(league: Any | None = None) -> Tuple[Dict[str, int], Dict[str, Set[str]]]:
+    """Public wrapper returning lineup slot counts and flex rules.
+
+    This function exposes the slot calculation logic so that other modules can
+    reason about roster construction without relying on the internal
+    ``_lineup_slots`` helper directly.
+    """
+
+    return _lineup_slots(league)
+
+
 def recommend_lineup(team: Any, league: Any | None = None) -> Dict[str, List[Dict[str, Any]]]:
     """Suggest a starting lineup based on projected points.
 
@@ -153,7 +164,7 @@ def recommend_lineup(team: Any, league: Any | None = None) -> Dict[str, List[Dic
     a standard configuration with a single FLEX spot is used.
     """
 
-    slots, flex_rules = _lineup_slots(league)
+    slots, flex_rules = lineup_slots(league)
     lineup: Dict[str, List[Dict[str, Any]]] = {slot: [] for slot in slots}
 
     players = sorted(

--- a/src/nf_llm/fantasy_football/espn_optimizer.py
+++ b/src/nf_llm/fantasy_football/espn_optimizer.py
@@ -1,0 +1,81 @@
+"""Lineup optimization utilities for ESPN fantasy football."""
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from .espn import lineup_slots, recommend_lineup, suggest_free_agents
+
+
+def build_optimal_lineup(
+    team: Any,
+    league: Any,
+    week: int | None = None,
+    limit: int = 5,
+) -> Dict[str, Any]:
+    """Construct the optimal lineup and highlight impactful pickups.
+
+    The function first generates a lineup from the current roster and then
+    considers available free agents.  If a free agent projects for more points
+    than the worst starter at a compatible position, they are inserted into the
+    lineup and recorded as a pickup suggestion.
+    """
+
+    lineup = recommend_lineup(team, league)
+    slots, flex_rules = lineup_slots(league)
+    suggestions = suggest_free_agents(league, team, week=week, limit=limit)
+
+    pickups: List[Dict[str, Any]] = []
+    for fa in suggestions:
+        pos = fa["position"]
+        fa_points = fa["projected_points"]
+
+        candidate_slots: List[str] = []
+        if pos in lineup:
+            candidate_slots.append(pos)
+        for flex_slot, allowed in flex_rules.items():
+            if pos in allowed:
+                candidate_slots.append(flex_slot)
+
+        best_slot = None
+        best_player = None
+        best_diff = 0.0
+        for slot in candidate_slots:
+            players = lineup.get(slot, [])
+            if not players:
+                diff = fa_points
+                if diff > best_diff:
+                    best_slot = slot
+                    best_player = None
+                    best_diff = diff
+            else:
+                worst = min(players, key=lambda p: p["projected_points"])
+                diff = fa_points - worst["projected_points"]
+                if diff > best_diff:
+                    best_slot = slot
+                    best_player = worst
+                    best_diff = diff
+
+        if best_slot and best_diff > 0:
+            if best_player:
+                lineup[best_slot].remove(best_player)
+                drop_name = best_player["name"]
+            else:
+                drop_name = None
+            lineup[best_slot].append(
+                {
+                    "name": fa["name"],
+                    "position": pos,
+                    "projected_points": fa_points,
+                }
+            )
+            pickups.append(
+                {
+                    "add": fa["name"],
+                    "position": pos,
+                    "slot": best_slot,
+                    "drop": drop_name,
+                    "projected_points_gain": round(best_diff, 1),
+                }
+            )
+
+    return {"lineup": lineup, "pickups": pickups}

--- a/tests/test_espn_optimizer.py
+++ b/tests/test_espn_optimizer.py
@@ -1,0 +1,57 @@
+import sys
+from pathlib import Path
+from unittest.mock import Mock
+
+# Ensure src directory is on path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from nf_llm.fantasy_football.espn_optimizer import build_optimal_lineup
+
+
+def test_build_optimal_lineup_recommends_free_agent():
+    def make_player(pos, name, pts):
+        p = Mock()
+        p.position = pos
+        p.name = name
+        p.projected_points = pts
+        return p
+
+    qb1 = make_player("QB", "QB1", 15)
+    qb2 = make_player("QB", "QB2", 10)
+    rb1 = make_player("RB", "RB1", 12)
+    rb2 = make_player("RB", "RB2", 8)
+    wr1 = make_player("WR", "WR1", 9)
+    wr2 = make_player("WR", "WR2", 7)
+    wr3 = make_player("WR", "WR3", 6)
+    te1 = make_player("TE", "TE1", 5)
+    dst = make_player("DST", "DST", 4)
+
+    team = Mock()
+    team.roster = [qb1, qb2, rb1, rb2, wr1, wr2, wr3, te1, dst]
+
+    settings = Mock()
+    settings.roster_positions = [
+        {"position": "QB", "count": 1},
+        {"position": "RB", "count": 2},
+        {"position": "WR", "count": 2},
+        {"position": "TE", "count": 1},
+        {"position": "RB/WR/TE", "count": 1},
+        {"position": "DST", "count": 1},
+    ]
+    league = Mock()
+    league.settings = settings
+
+    fa_better = make_player("WR", "FA_WR", 11)
+    league.free_agents.return_value = [fa_better]
+
+    result = build_optimal_lineup(team, league, week=1, limit=5)
+    assert any(p["name"] == "FA_WR" for p in result["lineup"]["WR"])
+    assert result["pickups"] == [
+        {
+            "add": "FA_WR",
+            "position": "WR",
+            "slot": "WR",
+            "drop": "WR2",
+            "projected_points_gain": 4.0,
+        }
+    ]


### PR DESCRIPTION
## Summary
- expose lineup slot configuration for reuse
- optimize ESPN lineups and recommend high-impact pickups
- surface optimal lineup and pickups in Streamlit UI and CLI

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install fastapi` *(fails: Could not find a version that satisfies the requirement fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_68b8c47988b08322924ec2c71adbad64