### PR TITLE
feat: add optimizer run DK CSV export

### DIFF
--- a/src/nf_llm/api/main.py
+++ b/src/nf_llm/api/main.py
@@ -20,6 +20,7 @@ class LineupRequest(BaseModel):
 
 
 class LineupResponse(BaseModel):
+    run_id: int
     lineups: list[dict[str, Any]]
 
 
@@ -48,7 +49,7 @@ def optimise(req: LineupRequest):
     Thin HTTP wrapper that delegates to the pure function.
     """
     try:
-        lineups = build_lineups(
+        run_id, lineups = build_lineups(
             csv_path=req.csv_path,
             slate_id=req.slate_id,
             constraints=req.constraints,
@@ -61,7 +62,7 @@ def optimise(req: LineupRequest):
         logging.error("Optimiser crashed:\n%s", traceback.format_exc())
         raise HTTPException(status_code=500, detail="Internal optimiser error") from err
 
-    return {"lineups": lineups}
+    return {"run_id": run_id, "lineups": lineups}
 
 
 @app.post("/undervalued-players", response_model=UndervaluedPlayersResponse)

--- a/src/nf_llm/api/main.py
+++ b/src/nf_llm/api/main.py
@@ -5,7 +5,7 @@ from typing import Any
 from fastapi import FastAPI, HTTPException, Response
 from pydantic import BaseModel, Field
 
-from nf_llm.service import build_lineups, export_dk_csv
+from nf_llm.service import build_lineups, export_dk_csv, export_run_dk_csv
 
 app = FastAPI(title="NF-LLM API", version="0.1.0")
 
@@ -85,7 +85,7 @@ def get_undervalued_players_endpoint(req: UndervaluedPlayersRequest):
         ) from err
 
 
-@app.post("/export/dk_csv")
+@app.post("/export/dk_csv", deprecated=True)
 def export_dk_csv_endpoint(req: DKCSVRequest):
     """Validate lineups and return a DraftKings upload CSV.
 
@@ -104,6 +104,27 @@ def export_dk_csv_endpoint(req: DKCSVRequest):
     headers = {}
     if invalid:
         headers["X-Invalid-Lineups"] = ",".join(str(i) for i in invalid)
+
+    return Response(content=csv_content, media_type="text/csv", headers=headers)
+
+
+@app.get("/optimizer_runs/{run_id}/export/dk_csv")
+def export_run_dk_csv_endpoint(run_id: int):
+    """Return a DraftKings CSV for a stored optimiser run."""
+
+    try:
+        csv_content, slate_id = export_run_dk_csv(run_id)
+    except FileNotFoundError as err:
+        raise HTTPException(status_code=404, detail=str(err))
+    except ValueError as err:
+        raise HTTPException(status_code=400, detail=str(err))
+    except Exception as err:  # pragma: no cover - unexpected errors
+        logging.error("DK CSV export crashed:\n%s", traceback.format_exc())
+        raise HTTPException(status_code=500, detail="Internal DK CSV error") from err
+
+    headers = {
+        "Content-Disposition": f"attachment; filename=\"{slate_id}_NFL_CLASSIC.csv\""
+    }
 
     return Response(content=csv_content, media_type="text/csv", headers=headers)
 

--- a/src/nf_llm/app.py
+++ b/src/nf_llm/app.py
@@ -73,9 +73,10 @@ def call_optimiser(csv_path: str, slate_id: str, constraints: dict):
     r = httpx.post(f"{API_ROOT}/optimise", json=payload, timeout=60)
     if r.status_code != 200:
         st.error(f"API returned {r.status_code}: {r.json()['detail']}")
-        return None  # caller can handle None gracefully
+        return None, None  # caller can handle None gracefully
 
-    return r.json()["lineups"]  # FastAPI guarantees this key
+    data = r.json()
+    return data.get("run_id"), data["lineups"]
 
 
 # Function to process user input and strategies
@@ -308,12 +309,12 @@ def show_optimizer_tab():
         constraints["max_exposure"] = max_exposure / 100  # Convert to decimal
         
         with st.spinner("Generating lineups..."):
-            lineups = call_optimiser(
+            run_id, lineups = call_optimiser(
                 csv_path="data/merged_fantasy_football_data.csv",
                 slate_id="DK‑NFL‑2025‑Week01",
                 constraints=constraints,
             )
-        st.session_state["last_run_id"] = st.session_state.get("last_run_id", 1)
+        st.session_state["last_run_id"] = run_id
 
         if not lineups:
             st.error("No lineups were generated.")
@@ -326,23 +327,32 @@ def show_optimizer_tab():
 
             run_id = st.session_state.get("last_run_id")
             if run_id is not None:
-                try:
-                    r = httpx.get(
-                        f"{API_ROOT}/optimizer_runs/{run_id}/export/dk_csv",
-                        timeout=60,
-                    )
-                except Exception as err:  # pragma: no cover - network failures
-                    st.error(f"API request failed: {err}")
-                else:
-                    if r.status_code == 200:
-                        st.download_button(
-                            "Export to DraftKings CSV",
-                            data=r.text,
-                            file_name=f"{run_id}_NFL_CLASSIC.csv",
-                            mime="text/csv",
+                if st.button("Export to DraftKings CSV"):
+                    try:
+                        r = httpx.get(
+                            f"{API_ROOT}/optimizer_runs/{run_id}/export/dk_csv",
+                            timeout=60,
                         )
+                    except Exception as err:  # pragma: no cover - network failures
+                        st.error(f"API request failed: {err}")
                     else:
-                        st.error(f"API returned {r.status_code}: {r.text}")
+                        if r.status_code == 200:
+                            st.session_state["dk_csv_bytes"] = r.content
+                            cd = r.headers.get("content-disposition", "")
+                            fname = f"{run_id}_NFL_CLASSIC.csv"
+                            if "filename=" in cd:
+                                fname = cd.split("filename=")[-1].strip('"')
+                            st.session_state["dk_csv_name"] = fname
+                        else:
+                            st.error(f"API returned {r.status_code}: {r.text}")
+
+            if "dk_csv_bytes" in st.session_state:
+                st.download_button(
+                    "Download DraftKings CSV",
+                    data=st.session_state["dk_csv_bytes"],
+                    file_name=st.session_state.get("dk_csv_name", "download.csv"),
+                    mime="text/csv",
+                )
 
 
 def show_lineups_tab():
@@ -384,7 +394,7 @@ def show_lineups_tab():
 
         st.download_button(
             "Download DK CSV",
-            data=r.text,
+            data=r.content,
             file_name="dk_lineups.csv",
             mime="text/csv",
         )

--- a/tests/test_export_run.py
+++ b/tests/test_export_run.py
@@ -1,0 +1,154 @@
+from pathlib import Path
+
+import duckdb
+from fastapi.testclient import TestClient
+
+from nf_llm.api.main import app
+
+client = TestClient(app)
+
+
+SLOTS = ["QB", "RB1", "RB2", "WR1", "WR2", "WR3", "TE", "FLEX", "DST"]
+POS_MAP = {
+    "QB": "QB",
+    "RB1": "RB",
+    "RB2": "RB",
+    "WR1": "WR",
+    "WR2": "WR",
+    "WR3": "WR",
+    "TE": "TE",
+    "FLEX": "RB",
+    "DST": "DST",
+}
+
+
+def _setup_db(tmp_path: Path):
+    db_path = tmp_path / "test.duckdb"
+    con = duckdb.connect(str(db_path))
+    con.execute(
+        "CREATE TABLE optimizer_lineups (lineup_id INT, run_id INT, slate_id TEXT)"
+    )
+    con.execute(
+        """
+        CREATE TABLE optimizer_lineup_players (
+            lineup_id INT,
+            slot TEXT,
+            player_id INT
+        )
+        """
+    )
+    con.execute(
+        """
+        CREATE TABLE salaries (
+            slate_id TEXT,
+            player_id INT,
+            dk_player_id TEXT,
+            pos TEXT
+        )
+        """
+    )
+    return con, db_path
+
+
+def test_export_run_dk_csv_success(tmp_path: Path, monkeypatch):
+    con, db_path = _setup_db(tmp_path)
+    monkeypatch.setenv("DATABASE_URL", f"duckdb:///{db_path}")
+
+    run_id = 1
+    slate = "SLATE1"
+    for lid in [1, 2, 3]:
+        con.execute(
+            "INSERT INTO optimizer_lineups VALUES (?, ?, ?)", [lid, run_id, slate]
+        )
+
+    for slot, pid in zip(SLOTS, range(1, 10), strict=False):
+        con.execute(
+            "INSERT INTO optimizer_lineup_players VALUES (1, ?, ?)", [slot, pid]
+        )
+    for slot, pid in zip(SLOTS, range(11, 20), strict=False):
+        con.execute(
+            "INSERT INTO optimizer_lineup_players VALUES (2, ?, ?)", [slot, pid]
+        )
+    for slot, pid in zip(SLOTS, range(21, 30), strict=False):
+        con.execute(
+            "INSERT INTO optimizer_lineup_players VALUES (3, ?, ?)", [slot, pid]
+        )
+
+    for slot, pid in zip(
+        SLOTS * 3,
+        list(range(1, 10)) + list(range(11, 20)) + list(range(21, 30)),
+        strict=False,
+    ):
+        pos = POS_MAP[slot]
+        con.execute(
+            "INSERT INTO salaries VALUES (?, ?, ?, ?)",
+            [slate, pid, f"{pid+1000}", pos],
+        )
+        if slot == "FLEX":
+            # duplicate FLEX row should be ignored in favour of positional row
+            con.execute(
+                "INSERT INTO salaries VALUES (?, ?, ?, 'FLEX')",
+                [slate, pid, f"{pid+2000}"],
+            )
+    con.close()
+
+    resp = client.get(f"/optimizer_runs/{run_id}/export/dk_csv")
+    assert resp.status_code == 200
+    assert resp.headers.get("content-type", "").startswith("text/csv")
+    assert (
+        resp.headers["content-disposition"]
+        == 'attachment; filename="SLATE1_NFL_CLASSIC.csv"'
+    )
+
+    lines = [ln for ln in resp.text.strip().split("\n") if ln]
+    assert lines[0] == "QB,RB,RB,WR,WR,WR,TE,FLEX,DST"
+    assert len(lines) == 4
+    assert lines[1] == "1001,1002,1003,1004,1005,1006,1007,1008,1009"
+    assert lines[2] == "1011,1012,1013,1014,1015,1016,1017,1018,1019"
+    assert lines[3] == "1021,1022,1023,1024,1025,1026,1027,1028,1029"
+
+
+def test_export_run_dk_csv_missing_player(tmp_path: Path, monkeypatch):
+    con, db_path = _setup_db(tmp_path)
+    monkeypatch.setenv("DATABASE_URL", f"duckdb:///{db_path}")
+
+    run_id = 2
+    slate = "SLATE1"
+    con.execute(
+        "INSERT INTO optimizer_lineups VALUES (1, ?, ?)", [run_id, slate]
+    )
+    for slot, pid in zip(SLOTS, range(1, 10), strict=False):
+        con.execute(
+            "INSERT INTO optimizer_lineup_players VALUES (1, ?, ?)", [slot, pid]
+        )
+    for slot, pid in zip(SLOTS, range(1, 10), strict=False):
+        if pid == 3:
+            continue  # omit salary mapping for player 3
+        pos = POS_MAP[slot]
+        con.execute(
+            "INSERT INTO salaries VALUES (?, ?, ?, ?)",
+            [slate, pid, f"{pid+1000}", pos],
+        )
+    con.close()
+
+    resp = client.get(f"/optimizer_runs/{run_id}/export/dk_csv")
+    assert resp.status_code == 400
+    assert "3" in resp.json()["detail"]
+
+
+def test_export_run_dk_csv_mixed_slate(tmp_path: Path, monkeypatch):
+    con, db_path = _setup_db(tmp_path)
+    monkeypatch.setenv("DATABASE_URL", f"duckdb:///{db_path}")
+
+    run_id = 3
+    con.execute(
+        "INSERT INTO optimizer_lineups VALUES (1, ?, 'S1')", [run_id]
+    )
+    con.execute(
+        "INSERT INTO optimizer_lineups VALUES (2, ?, 'S2')", [run_id]
+    )
+    con.close()
+
+    resp = client.get(f"/optimizer_runs/{run_id}/export/dk_csv")
+    assert resp.status_code == 400
+    assert "multiple slates" in resp.json()["detail"].lower()


### PR DESCRIPTION
## Summary
- support single-click DraftKings CSV export using optimizer run ID
- add temporary deprecation notice for old export endpoint
- show download button in optimizer results panel
- test run export including error handling cases

## Testing
- `ruff check src/nf_llm/service.py src/nf_llm/api/main.py src/nf_llm/app.py tests/test_export_run.py`
- `pytest tests/test_export_run.py::test_export_run_dk_csv_success -q` *(fails: ModuleNotFoundError: No module named 'duckdb')*
- `pip install fastapi duckdb` *(fails: Could not find a version that satisfies the requirement fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_68bc831753a08322bde0aa47ba64b3d0